### PR TITLE
rfc: use primary tag instead of primary.pronouns.domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It is recommended to use the same number of segments for each record, however th
 
 ## Multiple Records
 
-If you use or are comfortable with multiple sets of pronouns, you can create additional TXT records with the name `pronouns`. To indicate your preferred or default set, append `; primary` to the record's content.'
+If you use or are comfortable with multiple sets of pronouns, you can create additional TXT records with the name `pronouns`. To indicate your preferred or default set, append `; primary` to the record's content. If multiple records are marked as primary, clients may pick any of them as the primary set.
 
 **Example:**
 


### PR DESCRIPTION
This PR/RFC changes the mechanism by which primary pronouns are specified to avoid superfluous network requests.

Currently, two calls are required to resolve both `primary.pronouns.domain.tld` and `pronouns.domain.tld`. This PR/RFC proposes that this is instead marked on a field within a pronoun record, for example:

```dns
pronouns.domain.tld 300 IN TXT "she/her; preferred"
pronouns.domain.tld 300 IN TXT "they/them"
```
